### PR TITLE
Changes for compatibility with Autofac 5.0 develop

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="Autofac MyGet" value="https://www.myget.org/F/autofac/api/v2" />
+    <add key="NuGet v3" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+  <disabledPackageSources>
+    <add key="Microsoft and .NET" value="true" />
+  </disabledPackageSources>
+</configuration>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 4.1.0.{build}
+version: 5.0.0.{build}
 
 configuration: Release
 

--- a/src/Autofac.Integration.Mef/Autofac.Integration.Mef.csproj
+++ b/src/Autofac.Integration.Mef/Autofac.Integration.Mef.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Managed Extensibility Framework integration for Autofac. Enables MEF catalogs to be loaded by the Autofac container.</Description>
-    <VersionPrefix>4.1.0</VersionPrefix>
+    <VersionPrefix>5.0.0</VersionPrefix>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);IDE0008</NoWarn>
@@ -35,7 +35,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="4.9.1" />
+    <PackageReference Include="Autofac" Version="5.0.0-develop-00611" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.9.4">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>

--- a/src/Autofac.Integration.Mef/LazyWithMetadataRegistrationSource.cs
+++ b/src/Autofac.Integration.Mef/LazyWithMetadataRegistrationSource.cs
@@ -102,11 +102,11 @@ namespace Autofac.Integration.Mef
                 {
                     var context = c.Resolve<IComponentContext>();
                     return new Lazy<T, TMetadata>(
-                        () => (T)context.ResolveComponent(valueRegistration, p),
+                        () => (T)context.ResolveComponent(new ResolveRequest(providedService, valueRegistration, p)),
                         AttributedModelServices.GetMetadataView<TMetadata>(valueRegistration.Target.Metadata));
                 })
                 .As(providedService)
-                .Targeting(valueRegistration);
+                .Targeting(valueRegistration, true);
 
             return rb.CreateRegistration();
         }

--- a/src/Autofac.Integration.Mef/StronglyTypedMetadataRegistrationSource.cs
+++ b/src/Autofac.Integration.Mef/StronglyTypedMetadataRegistrationSource.cs
@@ -94,10 +94,10 @@ namespace Autofac.Integration.Mef
         {
             var rb = RegistrationBuilder
                 .ForDelegate((c, p) => new Meta<T, TMetadata>(
-                    (T)c.ResolveComponent(valueRegistration, p),
+                    (T)c.ResolveComponent(new ResolveRequest(providedService, valueRegistration, p)),
                     AttributedModelServices.GetMetadataView<TMetadata>(valueRegistration.Target.Metadata)))
                 .As(providedService)
-                .Targeting(valueRegistration);
+                .Targeting(valueRegistration, true);
 
             return rb.CreateRegistration();
         }


### PR DESCRIPTION
Fixes #14 

I'm unsure in one or two places if the correct thing is to instantiate a new ``ResolveRequest`` when I need it, rather than one being passed down from the Autofac Core.   I suspect it's just a workaround of sorts.

In the same way as with the MVC integration (https://github.com/autofac/Autofac.Mvc/issues/28), I can't help wondering if the Autofac Core should be passing the ``ResolveRequest`` down to the Activator when doing the activating, to make it available inside ``DelegateActivator`` callbacks.  

I had a quick look at what that would involve, but it would require changing the signature of ``IInstanceActivator.Activate`` to pass the ``ResolveRequest`` and I would appreciate some feedback from @alexmg as to whether that would be the correct approach, because it would be a big change.
