### PR TITLE
feat: Add As(Type) and AsNamed(Type) Method

### DIFF
--- a/src/Autofac.Integration.Mef/ExportConfigurationBuilder.cs
+++ b/src/Autofac.Integration.Mef/ExportConfigurationBuilder.cs
@@ -54,6 +54,17 @@ namespace Autofac.Integration.Mef
         }
 
         /// <summary>
+        /// Export the component under typed contract <paramref name="contractType"/>.
+        /// </summary>
+        /// <returns>Builder for additional configuration.</returns>
+        public ExportConfigurationBuilder As(Type contractType)
+        {
+            WithMetadata(CompositionConstants.ExportTypeIdentityMetadataName, AttributedModelServices.GetTypeIdentity(contractType));
+            ContractName = AttributedModelServices.GetContractName(contractType);
+            return this;
+        }
+
+        /// <summary>
         /// Export the component under named contract <paramref name="name"/>.
         /// </summary>
         /// <typeparam name="TExportedValue">Exported value type.</typeparam>
@@ -63,6 +74,19 @@ namespace Autofac.Integration.Mef
         {
             ContractName = name ?? throw new ArgumentNullException(nameof(name));
             WithMetadata(CompositionConstants.ExportTypeIdentityMetadataName, AttributedModelServices.GetTypeIdentity(typeof(TExportedValue)));
+            return this;
+        }
+
+        /// <summary>
+        /// Export the component under named contract <paramref name="name"/>.
+        /// </summary>
+        /// <param name="exportedValueType">Exported value type.</param>
+        /// <param name="name">Contract name.</param>
+        /// <returns>Builder for additional configuration.</returns>
+        public ExportConfigurationBuilder AsNamed(Type exportedValueType, string name)
+        {
+            ContractName = name ?? throw new ArgumentNullException(nameof(name));
+            WithMetadata(CompositionConstants.ExportTypeIdentityMetadataName, AttributedModelServices.GetTypeIdentity(exportedValueType));
             return this;
         }
 

--- a/src/Autofac.Integration.Mef/ExportConfigurationBuilder.cs
+++ b/src/Autofac.Integration.Mef/ExportConfigurationBuilder.cs
@@ -56,6 +56,7 @@ namespace Autofac.Integration.Mef
         /// <summary>
         /// Export the component under typed contract <paramref name="contractType"/>.
         /// </summary>
+        /// <param name="contractType">Contract type.</param>
         /// <returns>Builder for additional configuration.</returns>
         public ExportConfigurationBuilder As(Type contractType)
         {

--- a/test/Autofac.Integration.Mef.Test/DynamicTypeExportRegistrationTests.cs
+++ b/test/Autofac.Integration.Mef.Test/DynamicTypeExportRegistrationTests.cs
@@ -1,0 +1,197 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.ComponentModel.Composition.Hosting;
+using System.Linq;
+using System.Reflection;
+using Autofac.Core.Registration;
+using Autofac.Integration.Mef.Test.TestTypes;
+using Xunit;
+
+namespace Autofac.Integration.Mef.Test
+{
+    public class DynamicTypeExportRegistrationTests
+    {
+        [Fact]
+        public void ImportManyFromAutofacExports()
+        {
+            var builder = new ContainerBuilder();
+            var catalog = new TypeCatalog(typeof(ImportManyDependency));
+            builder.RegisterComposablePartCatalog(catalog);
+            RegisterAutofacDependencyUsingInterface(builder, true);
+            var container = builder.Build();
+            var resolve = container.Resolve<ImportManyDependency>();
+            Assert.Equal(2, resolve.Dependencies.Count());
+        }
+
+        [Fact]
+        public void ImportWithMetadataFromAutofacExports()
+        {
+            var builder = new ContainerBuilder();
+            var catalog = new TypeCatalog(typeof(ImportWithMetadataDependency));
+            builder.RegisterComposablePartCatalog(catalog);
+            const int metaInt = 10;
+            RegisterAutofacDependencyUsingAttribute(builder, "", metaInt);
+            var container = builder.Build();
+            var resolve = container.Resolve<ImportWithMetadataDependency>();
+            Assert.NotNull(resolve);
+            Assert.NotNull(resolve.Dependency.Value);
+            Assert.Equal(metaInt, resolve.Dependency.Metadata.TheInt);
+        }
+
+        [Fact]
+        public void RestrictsExportsBasedOnValueType()
+        {
+            var builder = new ContainerBuilder();
+            const string n = "name";
+            RegisterAutofacDependencyUsingAttribute(builder, n);
+            var container = builder.Build();
+            var exports = container.ResolveExports<IAutofacDependency>(n);
+            Assert.Empty(exports);
+        }
+
+        [Fact]
+        public void DuplicateConstructorDependencyImportUsingAttribute()
+        {
+            var builder = new ContainerBuilder();
+            var catalog = new TypeCatalog(typeof(ImportsDuplicateAutofacDependency));
+            builder.RegisterComposablePartCatalog(catalog);
+            RegisterAutofacDependencyUsingAttribute(builder);
+            var container = builder.Build();
+            var resolved = container.Resolve<ImportsDuplicateAutofacDependency>();
+            Assert.NotNull(resolved.First);
+            Assert.NotNull(resolved.Second);
+        }
+
+        [Fact]
+        public void DuplicateConstructorDependencyImportUsingInterface()
+        {
+            var builder = new ContainerBuilder();
+            var catalog = new TypeCatalog(typeof(ImportsDuplicateAutofacDependency));
+            builder.RegisterComposablePartCatalog(catalog);
+            RegisterAutofacDependencyUsingInterface(builder);
+            var container = builder.Build();
+            var resolved = container.Resolve<ImportsDuplicateAutofacDependency>();
+            Assert.NotNull(resolved.First);
+            Assert.NotNull(resolved.Second);
+        }
+
+        [Fact]
+        public void MixedDependencyConstructorDependencyImport()
+        {
+            var builder = new ContainerBuilder();
+            var catalog = new TypeCatalog(typeof(ImportsMixedAutofacMefDependency), typeof(MefDependency));
+            builder.RegisterComposablePartCatalog(catalog);
+            RegisterAutofacDependencyUsingAttribute(builder);
+            var container = builder.Build();
+            var resolved = container.Resolve<ImportsMixedAutofacMefDependency>();
+            Assert.NotNull(resolved.First);
+            Assert.NotNull(resolved.Second);
+        }
+
+        public static void RegisterAutofacDependencyUsingAttribute(ContainerBuilder builder, string name = "", int metaInt = 0)
+        {
+            foreach (Type type in Assembly.GetExecutingAssembly().GetTypes().Where(type =>
+                Attribute.GetCustomAttribute(type, typeof(ExportFromAutofacAttribute)) != null))
+            {
+                builder.RegisterType(type).Exported(x =>
+                {
+                    if (metaInt > 0)
+                    {
+                        x.As(type).WithMetadata("TheInt", metaInt);
+                    }
+                    else
+                    {
+                        if (string.IsNullOrEmpty(name))
+                            x.As(type);
+                        else x.AsNamed(type, name);
+                    }
+                });
+            }
+        }
+
+        public static void RegisterAutofacDependencyUsingInterface(
+            ContainerBuilder builder,
+            bool registerAsInterfaceType = false)
+        {
+            foreach (Type type in Assembly.GetExecutingAssembly().GetTypes().Where(type =>
+                typeof(IAutofacDependency).IsAssignableFrom(type) && !type.IsInterface))
+            {
+                builder.RegisterType(type)
+                    .Exported(x => x.As(registerAsInterfaceType ? typeof(IAutofacDependency) : type));
+            }
+        }
+
+        public interface IAutofacDependency
+        {
+        }
+
+        [ExportFromAutofac]
+        public class ExportFromAutofacDependencyA : IAutofacDependency
+        {
+        }
+
+        [ExportFromAutofac]
+        public class ExportFromAutofacDependencyB : IAutofacDependency
+        {
+        }
+
+        public interface IDependency
+        {
+        }
+
+        [Export(typeof(IDependency))]
+        public class MefDependency : IDependency
+        {
+        }
+
+        [Export]
+        public class ImportManyDependency
+        {
+            [ImportMany]
+            public IEnumerable<IAutofacDependency> Dependencies { get; set; }
+        }
+
+        [Export]
+        public class ImportWithMetadataDependency
+        {
+            [Import]
+            public Lazy<ExportFromAutofacDependencyB, IMetaWithDefault> Dependency { get; set; }
+        }
+
+        [Export]
+        public class ImportsDuplicateAutofacDependency
+        {
+            public ExportFromAutofacDependencyA First { get; }
+
+            public ExportFromAutofacDependencyB Second { get; }
+
+            [ImportingConstructor]
+            public ImportsDuplicateAutofacDependency(ExportFromAutofacDependencyA first, ExportFromAutofacDependencyB second)
+            {
+                First = first;
+                Second = second;
+            }
+        }
+
+        [Export]
+        public class ImportsMixedAutofacMefDependency
+        {
+            public ExportFromAutofacDependencyA First { get; }
+
+            public IDependency Second { get; }
+
+            [ImportingConstructor]
+            public ImportsMixedAutofacMefDependency(ExportFromAutofacDependencyA first, IDependency second)
+            {
+                First = first;
+                Second = second;
+            }
+        }
+
+        [AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = true)]
+        sealed class ExportFromAutofacAttribute : Attribute
+        {
+        }
+    }
+}

--- a/test/Autofac.Integration.Mef.Test/DynamicTypeExportRegistrationTests.cs
+++ b/test/Autofac.Integration.Mef.Test/DynamicTypeExportRegistrationTests.cs
@@ -89,6 +89,7 @@ namespace Autofac.Integration.Mef.Test
             Assert.NotNull(resolved.Second);
         }
 
+        [Theory]
         public static void RegisterAutofacDependencyUsingAttribute(ContainerBuilder builder, string name = "", int metaInt = 0)
         {
             foreach (Type type in Assembly.GetExecutingAssembly().GetTypes().Where(type =>
@@ -110,6 +111,7 @@ namespace Autofac.Integration.Mef.Test
             }
         }
 
+        [Theory]
         public static void RegisterAutofacDependencyUsingInterface(
             ContainerBuilder builder,
             bool registerAsInterfaceType = false)
@@ -190,7 +192,7 @@ namespace Autofac.Integration.Mef.Test
         }
 
         [AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = true)]
-        sealed class ExportFromAutofacAttribute : Attribute
+        public sealed class ExportFromAutofacAttribute : Attribute
         {
         }
     }


### PR DESCRIPTION
Add `As(Type)` and `AsNamed(Type)` method in `ExportConfigurationBuilder` class to support dynamic type in runtime reflection.

Example Usage - Register all types with `[RuminoidGlobalInstance]` and export them:

```cs
foreach (Type type in AppDomain.CurrentDomain.GetAssemblies().SelectMany(ass => ass.GetTypes())
    .Where(type => Attribute.GetCustomAttribute(type, typeof(RuminoidGlobalInstanceAttribute)) != null))
    builder.RegisterType(type).SingleInstance().Exported(x => x.As(type));
```

https://github.com/Ruminoid/Studio/blob/5f2ccb5a05bbf7c64d16b356ffb7a622007e9375/Ruminoid.Studio/Plugin/PluginManager.cs#L42-L44