### PR TITLE
Fix #23: Set registration sources to not be IsAdapterForIndividualComponents

### DIFF
--- a/src/Autofac.Integration.Mef/LazyWithMetadataRegistrationSource.cs
+++ b/src/Autofac.Integration.Mef/LazyWithMetadataRegistrationSource.cs
@@ -58,7 +58,7 @@ namespace Autofac.Integration.Mef
         {
             get
             {
-                return true;
+                return false;
             }
         }
 

--- a/src/Autofac.Integration.Mef/StronglyTypedMetadataRegistrationSource.cs
+++ b/src/Autofac.Integration.Mef/StronglyTypedMetadataRegistrationSource.cs
@@ -30,7 +30,7 @@ namespace Autofac.Integration.Mef
         {
             get
             {
-                return true;
+                return false;
             }
         }
 

--- a/test/Autofac.Integration.Mef.Test/LifetimeScenariosTests.cs
+++ b/test/Autofac.Integration.Mef.Test/LifetimeScenariosTests.cs
@@ -1,23 +1,110 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System;
+using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.ComponentModel.Composition.Hosting;
+using System.Linq;
 using System.Reflection;
+using Autofac.Features.Metadata;
+using Autofac.Integration.Mef.Test.TestTypes;
 using Xunit;
 
 namespace Autofac.Integration.Mef.Test
 {
-    /// <summary>
-    /// See Autofac Issue 128 (courtesy of palpatine@kopernet.org).
-    /// </summary>
     public class LifetimeScenariosTests
     {
-        public class RegisteredInAutofac2
+        [Fact]
+        public void ClassRegisteredInAutofacAsFactoryScopedIsResolvedByMefAsFactoryScoped()
+        {
+            var containerBuilder = new ContainerBuilder();
+
+            var newAssemblyCatalog = new AssemblyCatalog(Assembly.GetExecutingAssembly());
+            containerBuilder.RegisterComposablePartCatalog(newAssemblyCatalog);
+            containerBuilder.RegisterType<RegisteredInAutofac>();
+            containerBuilder.RegisterType<RegisteredInAutofacAndExported>()
+                .Exported(e => e.As<RegisteredInAutofacAndExported>());
+
+            var autofacContainer = containerBuilder.Build();
+
+            var elementFromAutofac1 = autofacContainer.Resolve<RegisteredInAutofac>();
+            var elementFromAutofac2 = autofacContainer.Resolve<RegisteredInAutofac>();
+
+            Assert.NotSame(elementFromAutofac1, elementFromAutofac2);
+            Assert.NotSame(elementFromAutofac1.ImportedFormMef, elementFromAutofac2.ImportedFormMef);
+            Assert.NotSame(elementFromAutofac1.ImportedFormMef.ImportedFormAutofac, elementFromAutofac2.ImportedFormMef.ImportedFormAutofac);
+        }
+
+        [Fact]
+        public void LazyMetadataRegistrationSourceDoesNotDuplicateDependencies()
+        {
+            // Issue #23 - configuration action on BeginLifetimeScope causes duplicate resolutions.
+            var builder = new ContainerBuilder();
+            builder.RegisterMetadataRegistrationSources();
+            builder.RegisterAssemblyTypes(typeof(LifetimeScenariosTests).Assembly)
+                    .AssignableTo<IDependency>()
+                    .As<IDependency>()
+                    .WithMetadataFrom<IMeta>();
+            var container = builder.Build();
+
+            using (var scope = container.BeginLifetimeScope())
+            {
+                var deps = scope.Resolve<IEnumerable<Lazy<IDependency, IMeta>>>();
+                Assert.Equal(2, deps.Count());
+            }
+
+            using (var scope = container.BeginLifetimeScope(b => { }))
+            {
+                var deps = scope.Resolve<IEnumerable<Lazy<IDependency, IMeta>>>();
+                Assert.Equal(2, deps.Count());
+            }
+        }
+
+        [Fact]
+        public void StronglyTypedMetadataRegistrationSourceDoesNotDuplicateDependencies()
+        {
+            // Issue #23 - configuration action on BeginLifetimeScope causes duplicate resolutions.
+            var builder = new ContainerBuilder();
+            builder.RegisterMetadataRegistrationSources();
+            builder.RegisterAssemblyTypes(typeof(LifetimeScenariosTests).Assembly)
+                    .AssignableTo<IDependency>()
+                    .As<IDependency>()
+                    .WithMetadataFrom<IMeta>();
+            var container = builder.Build();
+
+            using (var scope = container.BeginLifetimeScope())
+            {
+                var deps = scope.Resolve<IEnumerable<Meta<IDependency, IMeta>>>();
+                Assert.Equal(2, deps.Count());
+            }
+
+            using (var scope = container.BeginLifetimeScope(b => { }))
+            {
+                var deps = scope.Resolve<IEnumerable<Meta<IDependency, IMeta>>>();
+                Assert.Equal(2, deps.Count());
+            }
+        }
+
+        public interface IDependency
+        {
+        }
+
+        [Meta(1)]
+        public class Dependency1 : IDependency
+        {
+        }
+
+        [Meta(2)]
+        public class Dependency2 : IDependency
+        {
+        }
+
+        public class RegisteredInAutofac
         {
             public ExportedToMefAndImportingFromAutofac ImportedFormMef { get; set; }
 
-            public RegisteredInAutofac2(ExportedToMefAndImportingFromAutofac importedFormMef)
+            public RegisteredInAutofac(ExportedToMefAndImportingFromAutofac importedFormMef)
             {
                 ImportedFormMef = importedFormMef;
             }
@@ -33,27 +120,6 @@ namespace Autofac.Integration.Mef.Test
 
         public class RegisteredInAutofacAndExported
         {
-        }
-
-        [Fact]
-        public void ClassRegisteredInAutofacAsFactoryScopedIsResolvedByMefAsFactoryScoped()
-        {
-            var containerBuilder = new ContainerBuilder();
-
-            var newAssemblyCatalog = new AssemblyCatalog(Assembly.GetExecutingAssembly());
-            containerBuilder.RegisterComposablePartCatalog(newAssemblyCatalog);
-            containerBuilder.RegisterType<RegisteredInAutofac2>();
-            containerBuilder.RegisterType<RegisteredInAutofacAndExported>()
-                .Exported(e => e.As<RegisteredInAutofacAndExported>());
-
-            var autofacContainer = containerBuilder.Build();
-
-            var elementFromAutofac1 = autofacContainer.Resolve<RegisteredInAutofac2>();
-            var elementFromAutofac2 = autofacContainer.Resolve<RegisteredInAutofac2>();
-
-            Assert.NotSame(elementFromAutofac1, elementFromAutofac2);
-            Assert.NotSame(elementFromAutofac1.ImportedFormMef, elementFromAutofac2.ImportedFormMef);
-            Assert.NotSame(elementFromAutofac1.ImportedFormMef.ImportedFormAutofac, elementFromAutofac2.ImportedFormMef.ImportedFormAutofac);
         }
     }
 }

--- a/test/Autofac.Integration.Mef.Test/TestTypes/MetaAttribute.cs
+++ b/test/Autofac.Integration.Mef.Test/TestTypes/MetaAttribute.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.ComponentModel.Composition;
+
+namespace Autofac.Integration.Mef.Test.TestTypes
+{
+    [MetadataAttribute]
+    public class MetaAttribute : Attribute, IMeta
+    {
+        public MetaAttribute(int value) => TheInt = value;
+
+        public int TheInt { get; private set; }
+    }
+}


### PR DESCRIPTION
Added failing tests for #23 and verified that changing both registration sources to `IsAdapterForIndividualComponents = false` fixes the issue where duplicate components are registered in child scopes.