### PR TITLE
Update dependencies (Autofac 9.3.1)

### DIFF
--- a/default.proj
+++ b/default.proj
@@ -2,7 +2,7 @@
 <Project DefaultTargets="All" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="Current">
   <PropertyGroup>
     <!-- Increment the overall semantic version here. -->
-    <Version>8.0.0</Version>
+    <Version>8.0.1</Version>
     <SolutionName>Autofac.Mef</SolutionName>
     <Configuration Condition="'$(Configuration)'==''">Release</Configuration>
     <ArtifactDirectory>$([System.IO.Path]::Combine($(MSBuildProjectDirectory),"artifacts"))</ArtifactDirectory>

--- a/src/Autofac.Integration.Mef/Autofac.Integration.Mef.csproj
+++ b/src/Autofac.Integration.Mef/Autofac.Integration.Mef.csproj
@@ -53,7 +53,7 @@
     <AdditionalFiles Include="..\..\build\stylecop.json" Link="stylecop.json" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="9.3.0" />
+    <PackageReference Include="Autofac" Version="9.3.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" Condition="Exists('$(MSBuildThisFileDirectory)../../.git')">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
## Summary

- Updated `Autofac` package reference from 9.3.0 to 9.3.1 in `src/Autofac.Integration.Mef/Autofac.Integration.Mef.csproj`
- Bumped package version from 8.0.0 to 8.0.1 in `default.proj`

## Changes

| Package | Project | Old Version | New Version | Category |
|---------|---------|-------------|-------------|----------|
| Autofac | src (shipping) | 9.3.0 | 9.3.1 | Autofac ref (patch) |

No test-only or other shipping dependency changes.

## Test plan

- [ ] CI build passes
- [ ] All tests pass